### PR TITLE
Authentication and Employee authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>1.18.34</version>

--- a/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
+++ b/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
@@ -1,31 +1,52 @@
 package com.example.wdmsystem.config;
 
+import com.example.wdmsystem.employee.system.authentication.CustomUserDetailsService;
+import com.example.wdmsystem.util.JwtAuthTokenFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-public class SecurityConfig{
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthTokenFilter jwtAuthTokenFilter;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public SecurityConfig(JwtAuthTokenFilter jwtAuthTokenFilter, CustomUserDetailsService customUserDetailsService) {
+        this.jwtAuthTokenFilter = jwtAuthTokenFilter;
+        this.customUserDetailsService = customUserDetailsService;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // Disable CSRF (for development; re-enable for production)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
+                        .requestMatchers("/login").permitAll()
+                        .requestMatchers("/employees/**").hasAnyRole("ADMIN", "OWNER")
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthTokenFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        return http.getSharedObject(AuthenticationManagerBuilder.class).build();
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder
+                .userDetailsService(customUserDetailsService)
+                .passwordEncoder(passwordEncoder());
+        return authenticationManagerBuilder.build();
     }
 
     @Bean

--- a/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
+++ b/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
@@ -2,11 +2,16 @@ package com.example.wdmsystem.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-public class SecurityConfig {
+public class SecurityConfig{
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -16,5 +21,15 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 );
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class).build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
+++ b/src/main/java/com/example/wdmsystem/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login").permitAll()
                         .requestMatchers("/employees/**").hasAnyRole("ADMIN", "OWNER")
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll() //Temporary, will change as the other modules are updated.
                 )
                 .addFilterBefore(jwtAuthTokenFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/wdmsystem/customer/system/CustomerController.java
+++ b/src/main/java/com/example/wdmsystem/customer/system/CustomerController.java
@@ -8,9 +8,6 @@ import com.example.wdmsystem.reservation.system.Reservation;
 import java.util.Date;
 import java.util.List;
 
-//TODO: Request validation
-//TODO: Error response codes
-//TODO: Custom response messages
 @RestController
 public final class CustomerController {
 
@@ -27,7 +24,6 @@ public final class CustomerController {
     }
 
     /// In the API contract Limit is an entity, but in the doc it isn't mentioned.
-    //TODO: Decide which package Limit should be in. (It is used in several modules)
     @GetMapping("/customers")
     ResponseEntity<List<Customer>> getCustomers(@RequestParam(required = false) Date createdAtMin,
                                                 @RequestParam(required = false) Date createdAtMax,

--- a/src/main/java/com/example/wdmsystem/employee/system/CreateEmployeeDTO.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/CreateEmployeeDTO.java
@@ -1,0 +1,5 @@
+package com.example.wdmsystem.employee.system;
+
+public record CreateEmployeeDTO(String firstName, String lastName, EmployeeType employeeType, String username,
+                                String password) {
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/Employee.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/Employee.java
@@ -17,7 +17,8 @@ public final class Employee {
     //TODO: Add string restrictions of max length 30
     public String firstName;
     public String lastName;
-    @Enumerated(EnumType.STRING)
+    //It is saved as an int in the database
+    @Enumerated(EnumType.ORDINAL)
     public EmployeeType employeeType;
     public String username;
     public String password;

--- a/src/main/java/com/example/wdmsystem/employee/system/EmployeeController.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/EmployeeController.java
@@ -2,15 +2,13 @@ package com.example.wdmsystem.employee.system;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-//TODO: Request validation
-//TODO: Error response codes
-//TODO: Custom response messages
 @RestController
-public final class EmployeeController {
+public class EmployeeController {
     private final EmployeeService _employeeService;
 
     public EmployeeController(EmployeeService employeeService) {
@@ -18,31 +16,37 @@ public final class EmployeeController {
     }
 
     @PostMapping("/employees")
-    ResponseEntity<Employee> createEmployee(@RequestBody EmployeeDTO request) {
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_OWNER')")
+    ResponseEntity<Employee> createEmployee(@RequestBody CreateEmployeeDTO request) {
         Employee newEmployee = _employeeService.createEmployee(request);
         return new ResponseEntity<>(newEmployee, HttpStatus.CREATED);
     }
 
     @GetMapping("/employees")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_OWNER')")
     ResponseEntity<List<Employee>> getEmployees(@RequestParam EmployeeType type,
-                                                @RequestParam(required = false) int limit) {
+                                                @RequestParam(required = false) Integer limit) {
+
         List<Employee> employees = _employeeService.getEmployees(type, limit);
         return new ResponseEntity<>(employees, HttpStatus.OK);
     }
 
     @GetMapping("/employees/{employeeId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or (hasRole('ROLE_OWNER') and @employeeService.isOwnedByCurrentUser(#employeeId))")
     ResponseEntity<Employee> getEmployee(@PathVariable int employeeId) {
         Employee employee = _employeeService.getEmployee(employeeId);
         return new ResponseEntity<>(employee, HttpStatus.OK);
     }
 
     @PutMapping("/employees/{employeeId}")
-    ResponseEntity<Employee> updateEmployee(@PathVariable int employeeId, @RequestBody EmployeeDTO request) {
+    @PreAuthorize("hasRole('ROLE_ADMIN') or (hasRole('ROLE_OWNER') and @employeeService.isOwnedByCurrentUser(#employeeId))")
+    ResponseEntity<Employee> updateEmployee(@PathVariable int employeeId, @RequestBody UpdateEmployeeDTO request) {
         _employeeService.updateEmployee(employeeId, request);
         return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/employees/{employeeId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or (hasRole('ROLE_OWNER') and @employeeService.isOwnedByCurrentUser(#employeeId))")
     ResponseEntity<Employee> deleteEmployee(@PathVariable int employeeId) {
         _employeeService.deleteEmployee(employeeId);
         return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);

--- a/src/main/java/com/example/wdmsystem/employee/system/EmployeeDTO.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/EmployeeDTO.java
@@ -1,6 +1,0 @@
-package com.example.wdmsystem.employee.system;
-
-/// CreateEmployee is used as a DTO in both creation and updates, so renamed to a more general term
-public record EmployeeDTO(String firstName, String lastName, EmployeeType employeeType, String username,
-                          String password) {
-}

--- a/src/main/java/com/example/wdmsystem/employee/system/EmployeeService.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/EmployeeService.java
@@ -2,7 +2,9 @@ package com.example.wdmsystem.employee.system;
 
 import com.example.wdmsystem.exception.InvalidInputException;
 import com.example.wdmsystem.exception.NotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Limit;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -13,12 +15,16 @@ import java.util.List;
 public class EmployeeService {
     private final IEmployeeRepository employeeRepository;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     public EmployeeService(IEmployeeRepository employeeRepository) {
         this.employeeRepository = employeeRepository;
     }
 
     public Employee createEmployee(EmployeeDTO request) {
 
+        String hashedPassword = passwordEncoder.encode(request.password());
         Employee employee = new Employee(
                 0,
                 0, // placeholder
@@ -26,7 +32,7 @@ public class EmployeeService {
                 request.lastName(),
                 request.employeeType(),
                 request.username(),
-                request.password(),
+                hashedPassword,
                 LocalDateTime.now()
         );
         employee.setUpdatedAt(employee.getCreatedAt());
@@ -58,7 +64,8 @@ public class EmployeeService {
         employee.setLastName(request.lastName());
         employee.setEmployeeType(request.employeeType());
         employee.setUsername(request.username());
-        employee.setPassword(request.password());
+        String hashedPassword = passwordEncoder.encode(request.password());
+        employee.setPassword(hashedPassword);
         employee.setUpdatedAt(LocalDateTime.now());
 
         employeeRepository.save(employee);

--- a/src/main/java/com/example/wdmsystem/employee/system/EmployeeService.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/EmployeeService.java
@@ -1,14 +1,14 @@
 package com.example.wdmsystem.employee.system;
 
-import com.example.wdmsystem.exception.InvalidInputException;
+import com.example.wdmsystem.employee.system.authentication.CustomUserDetails;
 import com.example.wdmsystem.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Limit;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -22,12 +22,15 @@ public class EmployeeService {
         this.employeeRepository = employeeRepository;
     }
 
-    public Employee createEmployee(EmployeeDTO request) {
+    public Employee createEmployee(CreateEmployeeDTO request) {
+        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
 
         String hashedPassword = passwordEncoder.encode(request.password());
         Employee employee = new Employee(
                 0,
-                0, // placeholder
+                currentUser.getMerchantId(),
                 request.firstName(),
                 request.lastName(),
                 request.employeeType(),
@@ -40,13 +43,25 @@ public class EmployeeService {
         return employeeRepository.save(employee);
     }
 
-    public List<Employee> getEmployees(EmployeeType type, int limit) {
+    public List<Employee> getEmployees(EmployeeType type, Integer limit) {
 
-        if (limit <= 0) {
+        if (limit == null || limit <= 0) {
             limit = 50;
         }
 
-        return employeeRepository.getEmployeesByEmployeeType(type, Limit.of(limit));
+        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+
+        boolean isAdmin = currentUser.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+
+        System.out.println(isAdmin);
+        if(isAdmin) {
+            return employeeRepository.getEmployeesByEmployeeType(type, Limit.of(limit));
+        } else {
+            return employeeRepository.getEmployeesByEmployeeTypeAndMerchantId(type, currentUser.getMerchantId(), Limit.of(limit));
+        }
     }
 
     public Employee getEmployee(int employeeId) {
@@ -55,7 +70,7 @@ public class EmployeeService {
                 () -> new NotFoundException("Employee with id " + employeeId + " not found"));
     }
 
-    public void updateEmployee(int employeeId, EmployeeDTO request) {
+    public void updateEmployee(int employeeId, UpdateEmployeeDTO request) {
 
         Employee employee = employeeRepository.findById(employeeId).orElseThrow(
                 () -> new NotFoundException("Employee with id " + employeeId + " not found"));
@@ -64,10 +79,17 @@ public class EmployeeService {
         employee.setLastName(request.lastName());
         employee.setEmployeeType(request.employeeType());
         employee.setUsername(request.username());
-        String hashedPassword = passwordEncoder.encode(request.password());
-        employee.setPassword(hashedPassword);
+        employee.setPassword(passwordEncoder.encode(request.password()));
         employee.setUpdatedAt(LocalDateTime.now());
 
+        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+        boolean isAdmin = currentUser.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        if(isAdmin) {
+            employee.setMerchantId(request.merchantId());
+        }
         employeeRepository.save(employee);
     }
 
@@ -78,5 +100,15 @@ public class EmployeeService {
         else {
             throw new NotFoundException("Employee with id " + employeeId + " not found");
         }
+    }
+
+    //Not defined in yaml, but added for auth. Owners can only edit their own employees.
+    public boolean isOwnedByCurrentUser(int employeeId) {
+        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+
+        Employee employee = getEmployee(employeeId);
+        return employee.getMerchantId() == currentUser.getMerchantId();
     }
 }

--- a/src/main/java/com/example/wdmsystem/employee/system/EmployeeType.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/EmployeeType.java
@@ -2,6 +2,6 @@ package com.example.wdmsystem.employee.system;
 
 public enum EmployeeType {
     REGULAR,
-    ADMIN,
-    OWNER
+    OWNER,
+    ADMIN
 }

--- a/src/main/java/com/example/wdmsystem/employee/system/IEmployeeRepository.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/IEmployeeRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface IEmployeeRepository extends JpaRepository<Employee, Integer> {
     List<Employee> getEmployeesByEmployeeType(EmployeeType employeeType, Limit limit);
+    Optional<Employee> findByUsername(String username);
 }

--- a/src/main/java/com/example/wdmsystem/employee/system/IEmployeeRepository.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/IEmployeeRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 public interface IEmployeeRepository extends JpaRepository<Employee, Integer> {
     List<Employee> getEmployeesByEmployeeType(EmployeeType employeeType, Limit limit);
+    List<Employee> getEmployeesByEmployeeTypeAndMerchantId(EmployeeType employeeType, int merchantId, Limit limit);
     Optional<Employee> findByUsername(String username);
 }

--- a/src/main/java/com/example/wdmsystem/employee/system/UpdateEmployeeDTO.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/UpdateEmployeeDTO.java
@@ -1,0 +1,6 @@
+package com.example.wdmsystem.employee.system;
+
+/// CreateEmployee is used as a DTO in both creation and updates, separated them as they have different fields
+public record UpdateEmployeeDTO(int merchantId, String firstName, String lastName, EmployeeType employeeType, String username,
+                          String password) {
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
@@ -1,0 +1,36 @@
+package com.example.wdmsystem.employee.system.authentication;
+
+import com.example.wdmsystem.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthenticationController {
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private CustomUserDetailsService userDetailsService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody Login request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
+        );
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
+        String token = jwtUtil.generateToken(userDetails);
+
+        return ResponseEntity.ok(new LoginResponse(token));
+    }
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
@@ -28,8 +28,8 @@ public class AuthenticationController {
                 new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
         );
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
-        String token = jwtUtil.generateToken(userDetails);
+        CustomUserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
+        String token = jwtUtil.generateToken(userDetails, userDetails.getMerchantId());
 
         return ResponseEntity.ok(new LoginResponse(token));
     }

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/AuthenticationController.java
@@ -1,26 +1,26 @@
 package com.example.wdmsystem.employee.system.authentication;
 
 import com.example.wdmsystem.util.JwtUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class AuthenticationController {
-    @Autowired
-    private AuthenticationManager authenticationManager;
+    private final AuthenticationManager authenticationManager;
 
-    @Autowired
-    private JwtUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
-    @Autowired
-    private CustomUserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
+
+    public AuthenticationController(AuthenticationManager authenticationManager, JwtUtil jwtUtil, CustomUserDetailsService userDetailsService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody Login request) {

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetails.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetails.java
@@ -1,0 +1,42 @@
+package com.example.wdmsystem.employee.system.authentication;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final String username;
+    private final String password;
+    private final Integer merchantId;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(String username, String password, Integer merchantId, Collection<? extends GrantedAuthority> authorities) {
+        this.username = username;
+        this.password = password;
+        this.merchantId = merchantId;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.example.wdmsystem.employee.system.authentication;
+
+import com.example.wdmsystem.employee.system.Employee;
+import com.example.wdmsystem.employee.system.IEmployeeRepository;
+import com.example.wdmsystem.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private IEmployeeRepository employeeRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UnauthorizedException {
+        Employee employee = employeeRepository.findByUsername(username)
+                .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
+
+        return new org.springframework.security.core.userdetails.User(
+                employee.getUsername(),
+                employee.getPassword(),
+                List.of(new SimpleGrantedAuthority(employee.getEmployeeType().name()))
+        );
+    }
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
@@ -2,10 +2,9 @@ package com.example.wdmsystem.employee.system.authentication;
 
 import com.example.wdmsystem.employee.system.Employee;
 import com.example.wdmsystem.employee.system.IEmployeeRepository;
-import com.example.wdmsystem.exception.UnauthorizedException;
+import com.example.wdmsystem.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
@@ -18,14 +17,15 @@ public class CustomUserDetailsService implements UserDetailsService {
     private IEmployeeRepository employeeRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UnauthorizedException {
+    public CustomUserDetails loadUserByUsername(String username) {
         Employee employee = employeeRepository.findByUsername(username)
-                .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
+                .orElseThrow(() -> new NotFoundException("Employee not found: " + username));
 
-        return new org.springframework.security.core.userdetails.User(
+        return new CustomUserDetails(
                 employee.getUsername(),
                 employee.getPassword(),
-                List.of(new SimpleGrantedAuthority(employee.getEmployeeType().name()))
+                employee.getMerchantId(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + employee.getEmployeeType().name()))
         );
     }
 }

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/CustomUserDetailsService.java
@@ -3,7 +3,6 @@ package com.example.wdmsystem.employee.system.authentication;
 import com.example.wdmsystem.employee.system.Employee;
 import com.example.wdmsystem.employee.system.IEmployeeRepository;
 import com.example.wdmsystem.exception.NotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -13,8 +12,11 @@ import java.util.List;
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
-    @Autowired
-    private IEmployeeRepository employeeRepository;
+    private final IEmployeeRepository employeeRepository;
+
+    public CustomUserDetailsService(IEmployeeRepository employeeRepository) {
+        this.employeeRepository = employeeRepository;
+    }
 
     @Override
     public CustomUserDetails loadUserByUsername(String username) {

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/Login.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/Login.java
@@ -1,0 +1,13 @@
+package com.example.wdmsystem.employee.system.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Login {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/wdmsystem/employee/system/authentication/LoginResponse.java
+++ b/src/main/java/com/example/wdmsystem/employee/system/authentication/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.example.wdmsystem.employee.system.authentication;
+
+public record LoginResponse(String token) {
+}

--- a/src/main/java/com/example/wdmsystem/order/system/OrderItem.java
+++ b/src/main/java/com/example/wdmsystem/order/system/OrderItem.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public final class OrderItem {
+public class OrderItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     public int id;

--- a/src/main/java/com/example/wdmsystem/util/JwtAuthTokenFilter.java
+++ b/src/main/java/com/example/wdmsystem/util/JwtAuthTokenFilter.java
@@ -1,0 +1,86 @@
+package com.example.wdmsystem.util;
+
+import com.example.wdmsystem.employee.system.authentication.CustomUserDetails;
+import com.example.wdmsystem.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtAuthTokenFilter extends OncePerRequestFilter {
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String jwt = parseJwt(request);
+        if (jwt != null) {
+            try {
+                Claims claims = jwtUtil.validateToken(jwt);
+                String username = claims.getSubject();
+                List<String> roles = parseRoles(claims.get("roles"));
+                Integer merchantId = claims.get("merchantId", Integer.class);
+
+                List<GrantedAuthority> authorities = roles.stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+                CustomUserDetails userDetails = new CustomUserDetails(username, null, merchantId, authorities);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (Exception e) {
+                System.err.println("JWT Validation failed: " + e.getMessage());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private List<String> parseRoles(Object roles) {
+        List<String> rolesList = new ArrayList<>();
+
+        if (roles instanceof List<?> rolesListFromJwt) {
+            for (Object roleObject : rolesListFromJwt) {
+                if (roleObject instanceof LinkedHashMap<?, ?> roleMap) {
+                    Object authority = roleMap.get("authority");
+                    if (authority != null) {
+                        rolesList.add(authority.toString());
+                    }
+                } else {
+                    rolesList.add(roleObject.toString());
+                }
+            }
+        }
+        if (rolesList.isEmpty()) {
+            throw new UnauthorizedException("No roles found in JWT.");
+        }
+        return rolesList;
+    }
+
+    private String parseJwt(HttpServletRequest request) {
+        String headerAuth = request.getHeader("Authorization");
+        if (headerAuth != null && headerAuth.startsWith("Bearer ")) {
+            return headerAuth.substring(7);
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/example/wdmsystem/util/JwtAuthTokenFilter.java
+++ b/src/main/java/com/example/wdmsystem/util/JwtAuthTokenFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -23,8 +22,12 @@ import java.util.stream.Collectors;
 
 @Component
 public class JwtAuthTokenFilter extends OncePerRequestFilter {
-    @Autowired
-    private JwtUtil jwtUtil;
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthTokenFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/example/wdmsystem/util/JwtUtil.java
+++ b/src/main/java/com/example/wdmsystem/util/JwtUtil.java
@@ -1,0 +1,36 @@
+package com.example.wdmsystem.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private static final String SECRET_KEY = "VerySecureAndLongSecretKeyForJWTSigning";
+    private static final long EXPIRATION_TIME = 86400000; // 1 day
+
+    private final Key signingKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+    public String generateToken(org.springframework.security.core.userdetails.UserDetails userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .claim("roles", userDetails.getAuthorities())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(signingKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims validateToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(signingKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}


### PR DESCRIPTION
Added the login feature and role based access on employee management. There are some test employees in the database. I have made other http requests be available to all, but they will have to be restricted later.

The way it works:
- First you need to send a POST /login request with username and password in the body.  For testing i will put the user details in discord, as the passwords in the database are hashed. 
- You will get a token which will have to be put with all employee related http requests. (If you are using Postman, that's in the Authorization tab, of type Bearer token). The token is valid for a day.
- As a reminder, Admin can do everything, Owner can only edit employees with the same merchantId, Regular employees can't edit anything.

I also fixed some of the Employee service methods to include features that have role based access (for example only Admin can change the merchantId of a user). The EmployeeType is saved as an int in the database, so made changes in the code to reflect that. 

**In the put methods, the non required limit variable has to be of type Integer, because it can be null.**  I changed it in the Employee module, but that has to be fixed elsewhere too.